### PR TITLE
enable customization of compression backend order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - add `compression` parameter to define compression backend and order of preference
 - defaults to `gzip` -> `deflate` -> `br` order of preference (instead of `br` -> `gzip` -> `deflate`)
 - remove `exclude_encoder` parameter **breaking**
+- allow encoding `quality` values (e.g `gzip;0.9, deflate;0.2`)
 
 ## 0.2.0 (2022-06-03)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+
+## 0.3.0 (TBD)
+
+- add `compression` parameter to define compression backend and order of preference
+- defaults to `gzip` -> `deflate` -> `br` order of preference (instead of `br` -> `gzip` -> `deflate`)
+- remove `exclude_encoder` parameter **breaking**
+
 ## 0.2.0 (2022-06-03)
 
 - switch to `pyproject.toml`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ pip install https://github.com/developmentseed/starlette-cramjam.git
 
 The following arguments are supported:
 
+- **compression** (List of Compression) - List of available compression algorithm. **This list also defines the order of preference**. Defaults to `[Compression.gzip, Compression.deflate, Compression.br]`,
 - **minimum_size** (Integer) - Do not compress responses that are smaller than this minimum size in bytes. Defaults to `500`.
 - **exclude_path** (Set of string) - Do not compress responses in response to specific `path` requests. Entries have to be valid regex expressions. Defaults to `{}`.
 - **exclude_mediatype** (Set of string) - Do not compress responses of specific media type (e.g `image/png`). Defaults to `{}`.
@@ -93,6 +94,7 @@ import uvicorn
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse, Response
 
+from starlette_cramjam.compression import Compression
 from starlette_cramjam.middleware import CompressionMiddleware
 
 # create application
@@ -101,6 +103,7 @@ app = Starlette()
 # register the CompressionMiddleware
 app.add_middleware(
     CompressionMiddleware,
+    compression=[Compression.gzip],  # Only support `gzip`
     minimum_size=0,  # should compress everything
     exclude_path={"^/foo$"},  # do not compress response for the `/foo` request
     exclude_mediatype={"image/jpeg"},  # do not compress jpeg

--- a/starlette_cramjam/compression.py
+++ b/starlette_cramjam/compression.py
@@ -1,0 +1,25 @@
+"""starlette_cramjam.compression."""
+
+from enum import Enum
+from types import DynamicClassAttribute
+
+import cramjam
+
+compression_backends = {
+    "br": cramjam.brotli,
+    "deflate": cramjam.deflate,
+    "gzip": cramjam.gzip,
+}
+
+
+class Compression(str, Enum):
+    """Responses Media types formerly known as MIME types."""
+
+    gzip = "gzip"
+    br = "br"
+    deflate = "deflate"
+
+    @DynamicClassAttribute
+    def compress(self):
+        """Return cramjam backend."""
+        return compression_backends[self._name_]

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -8,6 +8,7 @@ from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse, Response, StreamingResponse
 from starlette.testclient import TestClient
 
+from starlette_cramjam.compression import Compression
 from starlette_cramjam.middleware import CompressionMiddleware
 
 
@@ -143,17 +144,18 @@ def test_compressed_skip_on_path(method):
 
 
 @pytest.mark.parametrize(
-    "exclude_encoder,expected",
+    "compression,expected",
     [
-        ({"br", "gzip"}, "deflate"),
-        ({"br", "deflate"}, "gzip"),
-        ({"gzip", "deflate"}, "br"),
+        ([], "gzip"),
+        ([Compression.gzip], "gzip"),
+        ([Compression.br, Compression.gzip], "br"),
+        ([Compression.gzip, Compression.br], "gzip"),
     ],
 )
-def test_compressed_skip_on_encoder(exclude_encoder, expected):
+def test_compressed_skip_on_encoder(compression, expected):
     app = Starlette()
 
-    app.add_middleware(CompressionMiddleware, exclude_encoder=exclude_encoder)
+    app.add_middleware(CompressionMiddleware, compression=compression)
 
     @app.route("/")
     def homepage(request):

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -191,6 +191,12 @@ def test_compressed_skip_on_encoder(compression, expected):
         ([Compression.gzip, Compression.br], "br;q=1.0, gzip;q=1.0", Compression.gzip),
         # br and gzip are equally preferred but br is the first available
         ([Compression.br, Compression.gzip], "br;q=1.0, gzip;q=1.0", Compression.br),
+        # br and gzip are available and client has no preference
+        ([Compression.br, Compression.gzip], "*;q=1.0", Compression.br),
+        # invalid br quality so ignored
+        ([Compression.br, Compression.gzip], "br;q=aaa, gzip", Compression.gzip),
+        # br quality is set to 0
+        ([Compression.br, Compression.gzip], "br;q=0.0, gzip", Compression.gzip),
     ],
 )
 def test_get_compression_backend(compression, header, expected):


### PR DESCRIPTION
closes #6 


cc @drnextgis this removes your previous `exclude_encoder` option to make the support of different compression more customizable and also let the user define the **order** of preference for the algorithm. 

This PR also change the previous order to `Gzip` first 