### PR TITLE
add compression_level option

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,0 @@
-[bumpversion]
-current_version = 0.3.3
-commit = True
-tag = True
-tag_name = {new_version}
-
-[bumpversion:file:starlette_cramjam/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.4.0 (2024-10-17)
+
+- add `compression_level` option
+- update `cramjam` version limit to `cramjam>=2.4,<2.10`
 
 ## 0.3.3 (2024-05-24)
 

--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ sys.getsizeof(gzip.compress(page, compresslevel=6))
 # ------------
 # With Cramjam
 # ------------
-%timeit cramjam.gzip.compress(page, level=4)
-# 2.38 ms ± 34 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+%timeit cramjam.gzip.compress(page, level=6)
+# 4.12 ms ± 57.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 
-cramjam.gzip.compress(page, level=4).len()
-# 56853
+cramjam.gzip.compress(page, level=6).len()
+# 55221
 
 %timeit cramjam.brotli.compress(page, level=4)
 # 2.3 ms ± 48.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["starlette", "cramjam>=2.4,<2.9"]
+dependencies = ["starlette", "cramjam>=2.4,<2.10"]
 
 [project.optional-dependencies]
 test = [
@@ -32,6 +32,7 @@ test = [
 ]
 dev = [
     "pre-commit",
+    "bump-my-version",
 ]
 
 [project.urls]
@@ -80,8 +81,22 @@ ignore = [
 [tool.ruff]
 line-length = 90
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["D1"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 12
+
+[tool.bumpversion]
+current_version = "0.3.3"
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+tag = true
+commit = true
+tag_name = "{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "starlette_cramjam/__init__.py"
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'

--- a/starlette_cramjam/compression.py
+++ b/starlette_cramjam/compression.py
@@ -6,9 +6,9 @@ from types import DynamicClassAttribute
 import cramjam
 
 compression_backends = {
-    "br": cramjam.brotli,
-    "deflate": cramjam.deflate,
-    "gzip": cramjam.gzip,
+    "br": cramjam.brotli,  # min: 0, max: 11, default: 11
+    "deflate": cramjam.deflate,  # min: 0, max: 9, default: 6
+    "gzip": cramjam.gzip,  # min: 0, max: 9, default: 6
 }
 
 


### PR DESCRIPTION
The levels for zlib/deflate/brotli don't have the same `max` values (11 for brotli, 9 for the others) but it seems that you can still use level=11 for deflate and zlib 🤷 

let see if https://github.com/milesgranger/cramjam/issues/187 get some response before we merge this PR 