### PR TITLE
ci: pin GitHub Actions to SHA digests (fix zizmor unpinned-uses)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
         - '3.14'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.9.*" 
           enable-cache: true
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload Results
         if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage.xml
           flags: unittests
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.9.*" 
           enable-cache: true


### PR DESCRIPTION
## Pin GitHub Actions to SHA digests

Zizmor detected **5** `unpinned-uses` findings in `.github/workflows/`.

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) are vulnerable to tag mutation — a compromised or hijacked tag can introduce malicious code into CI runs. Pinning to a full commit SHA (e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4`) eliminates this supply-chain risk.

This PR pins all workflow steps to their current SHA using [`pin-github-action`](https://github.com/mheap/pin-github-action), fixing 5 findings.

### Recommended next steps

1. Dependabot is already configured for `github-actions` in this repo — pinned SHAs will be kept up-to-date automatically.
2. Add [zizmor-action](https://github.com/zizmorcore/zizmor-action?tab=readme-ov-file#usage-with-github-advanced-security-recommended) for continuous workflow security scanning in CI.

### References

- [zizmor unpinned-uses audit](https://docs.zizmor.sh/audits/#unpinned-uses)
- [pin-github-action](https://github.com/mheap/pin-github-action)

---
_Generated by [ds-security-scanning](https://github.com/developmentseed/ds-security-scanning) zizmor-cli-unpinned-uses_